### PR TITLE
Keep rooms alive for one month

### DIFF
--- a/server/src/utilities/gameState.spec.ts
+++ b/server/src/utilities/gameState.spec.ts
@@ -16,7 +16,6 @@ const decompressStringMock = jest.mocked(decompressString)
 const getCurrentTimestampMock = jest.mocked(getCurrentTimestamp)
 
 const chance = new Chance()
-const oneDay = 86400
 
 const getRandomPlayers = (state: GameState, count?: number) =>
   chance.n(() => ({
@@ -159,7 +158,8 @@ describe('gameState', () => {
       expect(compressStringMock).toHaveBeenCalledTimes(1)
       expect(JSON.parse(actualStateString)).toEqual(expectedState)
       expect(setValueMock).toHaveBeenCalledTimes(1)
-      expect(setValueMock).toHaveBeenCalledWith(gameState.roomId.toUpperCase(), compressedStateString, oneDay)
+      const oneMonth = 2678400
+      expect(setValueMock).toHaveBeenCalledWith(gameState.roomId.toUpperCase(), compressedStateString, oneMonth)
     })
 
     it('should not update storage if state unchanged', async () => {

--- a/server/src/utilities/gameState.ts
+++ b/server/src/utilities/gameState.ts
@@ -102,10 +102,10 @@ export const validateGameState = (state: GameState) => {
 }
 
 const setGameState = async (roomId: string, newState: GameState) => {
-  const oneDay = 86400
+  const oneMonth = 2678400
   validateGameState(newState)
   const compressed = compressString(JSON.stringify(newState))
-  await setValue(roomId.toUpperCase(), compressed, oneDay)
+  await setValue(roomId.toUpperCase(), compressed, oneMonth)
 }
 
 export const createGameState = async (roomId: string, gameState: GameState) => {


### PR DESCRIPTION
If teams want to reuse links a few times a week, this would allow them to do so without creating a new room every time.