### PR TITLE
Remove state shim

### DIFF
--- a/server/src/utilities/gameState.ts
+++ b/server/src/utilities/gameState.ts
@@ -19,11 +19,6 @@ export const getGameState = async (
 
   const state = JSON.parse(decompressString(compressed))
 
-  // TODO: once all existing states have updated, this can be removed
-  state.players.forEach((player: Player) => {
-    if (!player.unclaimedInfluences) player.unclaimedInfluences = []
-  })
-
   state.lastEventTimestamp = new Date(state.lastEventTimestamp ?? null)
 
   return state


### PR DESCRIPTION
This pull request includes a small change to the `server/src/utilities/gameState.ts` file. The change removes a block of code that initializes the `unclaimedInfluences` property for players in the game state, which is no longer necessary. 

* [`server/src/utilities/gameState.ts`](diffhunk://#diff-82b5857651333aa4daa2a4b40fdc1e52c24cb3ce8d9e52b69938de2f687a81a0L22-L26): Removed the block of code that initializes `unclaimedInfluences` for each player, as it is now redundant.