### PR TITLE
Unclaim influence when previously called out and reduce bluff margin

### DIFF
--- a/server/src/game/actionHandlers.ts
+++ b/server/src/game/actionHandlers.ts
@@ -690,6 +690,7 @@ export const actionChallengeResponseHandler = async ({ roomId, playerId, influen
       const claimedInfluence = ActionAttributes[state.pendingAction!.action].influenceRequired
       if (claimedInfluence) {
         removeClaimedInfluence(actionPlayer, claimedInfluence)
+        addUnclaimedInfluence(actionPlayer, claimedInfluence)
       }
       holdGrudge({ state, offended: state.turnPlayer!, offender: challengePlayer.name, weight: grudgeSizes[Responses.Challenge] })
       killPlayerInfluence(state, actionPlayer.name, influence)

--- a/server/src/game/ai.ts
+++ b/server/src/game/ai.ts
@@ -230,7 +230,7 @@ export const decideAction = (gameState: PublicGameState): {
   const honesty = (gameState.selfPlayer.personality?.honesty ?? 50) / 100
   const skepticism = (gameState.selfPlayer.personality?.skepticism ?? 50) / 100
 
-  const baseBluffMargin = (1 - honesty) ** 1.5 * 0.5
+  const baseBluffMargin = (1 - honesty) ** 1.5 * 0.3
   const getFinalBluffMarginForAction = (influence: Influences) =>
     getFinalBluffMargin(baseBluffMargin, influence, gameState.selfPlayer!)
 


### PR DESCRIPTION
This pull request includes changes to the game logic in the `server/src/game` directory, specifically focusing on the handling of influences and decision-making for AI players. The most important changes are summarized below:

### Influence Handling:

* [`server/src/game/actionHandlers.ts`](diffhunk://#diff-8221862f9ea0a8f9d68c80d5345e547a33a4d4fe34af01fa331ffe5a220b7372R693): Added a call to `addUnclaimedInfluence` after removing claimed influence to ensure the player's influence is correctly updated.

### AI Decision-Making:

* [`server/src/game/ai.ts`](diffhunk://#diff-9fab1bcfd3884b0536a8aea33b14953ebfec280240f2ed60efc9c2c9fcd74562L233-R233): Adjusted the `baseBluffMargin` calculation by changing the multiplier from 0.5 to 0.3, which affects how the AI evaluates its bluffing strategy.