### PR TITLE
Failed block should add to unclaimed

### DIFF
--- a/server/src/game/actionHandlers.ts
+++ b/server/src/game/actionHandlers.ts
@@ -890,6 +890,7 @@ export const blockChallengeResponseHandler = async ({ roomId, playerId, influenc
         addClaimedInfluence(actionPlayer, claimedInfluence)
       }
       removeClaimedInfluence(blockPlayer, state.pendingBlock!.claimedInfluence)
+      addUnclaimedInfluence(blockPlayer, state.pendingBlock!.claimedInfluence)
       holdGrudge({ state, offended: blockPlayer.name, offender: challengePlayer.name, weight: grudgeSizes[Responses.Challenge] })
       killPlayerInfluence(state, blockPlayer.name, influence)
       processPendingAction(state)


### PR DESCRIPTION
This pull request includes a small change to the `server/src/game/actionHandlers.ts` file. The change ensures that when a block challenge response is handled, the influence claimed by the blocking player is added back to the unclaimed pool.

* [`server/src/game/actionHandlers.ts`](diffhunk://#diff-8221862f9ea0a8f9d68c80d5345e547a33a4d4fe34af01fa331ffe5a220b7372R893): Added a call to `addUnclaimedInfluence` to return the claimed influence of the block player to the unclaimed pool.