### PR TITLE
Fix some loading things

### DIFF
--- a/client/src/components/game/AddAiPlayer.tsx
+++ b/client/src/components/game/AddAiPlayer.tsx
@@ -164,7 +164,7 @@ function AddAiPlayer({ addAiPlayerDialogOpen, setAddAiPlayerDialogOpen }: {
           <Button
             type="submit"
             variant="contained"
-            disabled={isMutating}
+            loading={isMutating}
           >
             {t('add')}
           </Button>

--- a/client/src/components/game/PlayAgain.tsx
+++ b/client/src/components/game/PlayAgain.tsx
@@ -27,7 +27,7 @@ function PlayAgain() {
           })
         }}
         variant="contained"
-        disabled={isMutating}
+        loading={isMutating}
       >
         {t('playAgain')}
       </Button>

--- a/client/src/components/game/WaitingRoom.tsx
+++ b/client/src/components/game/WaitingRoom.tsx
@@ -96,7 +96,8 @@ function WaitingRoom() {
                 playerId: getPlayerId()
               })
             }}
-            disabled={gameState.players.length < 2 || isMutating}
+            disabled={gameState.players.length < 2}
+            loading={isMutating}
           >
             {(t('startGame'))}
           </Button>

--- a/client/src/components/pages/CreateGame.tsx
+++ b/client/src/components/pages/CreateGame.tsx
@@ -88,7 +88,7 @@ function CreateGame() {
             type="submit"
             sx={{ mt: 5 }}
             variant="contained"
-            disabled={isMutating}
+            loading={isMutating}
           >
             {t('createGame')}
           </Button>

--- a/client/src/components/pages/JoinGame.tsx
+++ b/client/src/components/pages/JoinGame.tsx
@@ -84,7 +84,7 @@ function JoinGame() {
             type="submit"
             sx={{ mt: 5 }}
             variant="contained"
-            disabled={isMutating}
+            loading={isMutating}
           >
             {t('joinGame')}
           </Button>


### PR DESCRIPTION
This pull request includes several changes to improve the user experience by updating the button states and enhancing the `useGameMutation` hook to handle socket timeouts more effectively. The most important changes include replacing the `disabled` prop with a `loading` prop for buttons during mutation states and adding a timeout mechanism in the `useGameMutation` hook.

Button state updates:

* [`client/src/components/game/AddAiPlayer.tsx`](diffhunk://#diff-d68fcf06e359c14fbfc1794e01214372afcae121dacb93f4c63fe2909a2d2b01L167-R167): Replaced `disabled` prop with `loading` prop for the submit button when `isMutating` is true.
* [`client/src/components/game/PlayAgain.tsx`](diffhunk://#diff-805281c7333f4ec152532205c100acf453f0ccdd5bc026208a137621bbd97510L30-R30): Replaced `disabled` prop with `loading` prop for the play again button when `isMutating` is true.
* [`client/src/components/game/WaitingRoom.tsx`](diffhunk://#diff-3718e2d91468c308b05cc030e65c923364e1feac6b860f6dc1b15fdf7f8f9055L99-R100): Separated `disabled` and `loading` props for the start game button to improve clarity.
* [`client/src/components/pages/CreateGame.tsx`](diffhunk://#diff-6ef9c7861b0e3395c51404caa6220b2997a5e61333df17c89116a1decfba27abL91-R91): Replaced `disabled` prop with `loading` prop for the create game button when `isMutating` is true.
* [`client/src/components/pages/JoinGame.tsx`](diffhunk://#diff-6d37edbdb131c78f00b2561436c6fc0788e968e31dbbb3666ac04f3c7bc3cc7cL87-R87): Replaced `disabled` prop with `loading` prop for the join game button when `isMutating` is true.

Enhancements to `useGameMutation` hook:

* [`client/src/hooks/useGameMutation.tsx`](diffhunk://#diff-869d45e8771f6a847d4bd5fde29cece14693cc183168b12ace0684ae4ddfd164L2-R2): Added `useRef` import and introduced a timeout mechanism to reset the `isMutatingSocket` state if no socket callback is received within 5 seconds. [[1]](diffhunk://#diff-869d45e8771f6a847d4bd5fde29cece14693cc183168b12ace0684ae4ddfd164L2-R2) [[2]](diffhunk://#diff-869d45e8771f6a847d4bd5fde29cece14693cc183168b12ace0684ae4ddfd164R12) [[3]](diffhunk://#diff-869d45e8771f6a847d4bd5fde29cece14693cc183168b12ace0684ae4ddfd164R39-R44)