### PR TITLE
Allow updating chat message text

### DIFF
--- a/client/src/components/chat/ChatDrawerContent.tsx
+++ b/client/src/components/chat/ChatDrawerContent.tsx
@@ -58,12 +58,14 @@ export default function ChatDrawerContent({
   }
 
   const sendMessage = () => {
-    trigger({
-      roomId: gameState.roomId,
-      playerId: getPlayerId(),
-      messageId: pendingMessageId,
-      messageText: pendingMessageText.trim()
-    })
+    if (!isMutating) {
+      trigger({
+        roomId: gameState.roomId,
+        playerId: getPlayerId(),
+        messageId: pendingMessageId,
+        messageText: pendingMessageText.trim()
+      })
+    }
   }
 
   return (
@@ -92,7 +94,7 @@ export default function ChatDrawerContent({
           }}
           size='small'
           sx={{ width: '100%' }}
-        ></TextField>
+        />
         <Button
           disabled={!sendEnabled}
           loading={isMutating}

--- a/server/src/game/actionHandlers.ts
+++ b/server/src/game/actionHandlers.ts
@@ -968,11 +968,18 @@ export const sendChatMessageHandler = async ({ roomId, playerId, messageId, mess
 
   const player = getPlayerInRoom(gameState, playerId)
 
-  if (gameState.chatMessages.some(({id}) => id === messageId)) {
-    throw new GameMutationInputError('This message id already exists')
-  }
-
   await mutateGameState(gameState, (state) => {
+    const existingMessage = state.chatMessages.find(({id}) => id === messageId)
+
+    if (existingMessage && existingMessage?.from !== player.name) {
+      throw new GameMutationInputError('This is not your message')
+    }
+
+    if (existingMessage) {
+      existingMessage.text = messageText
+      return
+    }
+
     state.chatMessages.push({
       id: messageId,
       text: messageText,


### PR DESCRIPTION
This pull request introduces the ability to edit chat messages in the chat interface, along with some minor UI improvements and server-side validation updates. The most important changes include adding a message editing feature, improving the `ChatDrawerContent` component, and enhancing server-side validation for message updates.

### Chat message editing feature:
* Added a new `editingMessage` state and `sendChatMessageMutation` in `ChatMessages` to handle editing messages. Users can edit their messages directly in the chat interface using a `TextField` with validation for maximum length and an "Enter" key submission. [[1]](diffhunk://#diff-f0a972f771cac8495ba1e054b8e401a85306cb2a20d0f2f53f2be4a693171f3dR14-R28) [[2]](diffhunk://#diff-f0a972f771cac8495ba1e054b8e401a85306cb2a20d0f2f53f2be4a693171f3dL67-R139)
* Introduced an `Edit` button for users to start editing their messages, along with `Cancel` and `Check` buttons to confirm or discard changes.

### UI improvements:
* Updated `ChatDrawerContent` to prevent sending messages while a mutation is in progress and fixed a minor issue with the `TextField` self-closing tag. [[1]](diffhunk://#diff-119b58eaefb57388cf3de58179cb2c0c9baf48d578f45f98ccc740aa6959e22fR61-R69) [[2]](diffhunk://#diff-119b58eaefb57388cf3de58179cb2c0c9baf48d578f45f98ccc740aa6959e22fL95-R97)

### Server-side validation:
* Enhanced the `sendChatMessageHandler` to allow editing existing messages if they belong to the current user, while preventing edits to messages from other users.