### PR TITLE
Only edit one message at a time

### DIFF
--- a/client/src/components/chat/ChatMessages.tsx
+++ b/client/src/components/chat/ChatMessages.tsx
@@ -87,7 +87,7 @@ export default function ChatMessages() {
                   }}
                 >
                   {deleted ? t('messageWasDeleted') : (
-                    editingMessage ? (
+                    editingMessage?.id === id ? (
                       <TextField
                         placeholder={t('writeNewMessage') as string}
                         label={`${editingMessage.text ? ` (${maxMessageLength - editingMessage.text.length}/${maxMessageLength})` : ''}`}


### PR DESCRIPTION
This pull request includes a small change to the `ChatMessages` component to fix a conditional check for editing messages.

* [`client/src/components/chat/ChatMessages.tsx`](diffhunk://#diff-f0a972f771cac8495ba1e054b8e401a85306cb2a20d0f2f53f2be4a693171f3dL90-R90): Updated the condition to check if `editingMessage?.id` matches the current message `id` instead of just checking if `editingMessage` exists. This ensures the correct message is being edited.