### PR TITLE
Fix flaky test

### DIFF
--- a/server/src/game/actionHandlers.spec.ts
+++ b/server/src/game/actionHandlers.spec.ts
@@ -339,7 +339,11 @@ describe('actionHandlers', () => {
     })
 
     it('revive', async () => {
-      const roomId = await setupTestGame([david, harper, { ...hailey, coins: 10, influences: [Influences.Assassin], deadInfluences: [Influences.Captain] }])
+      const roomId = await setupTestGame([
+        {...david, influences: [Influences.Duke, Influences.Contessa] },
+        {...harper, influences: [Influences.Captain, Influences.Ambassador] },
+        { ...hailey, coins: 10, influences: [Influences.Assassin], deadInfluences: [Influences.Captain] }
+      ])
 
       await expect(actionHandler({ roomId, playerId: david.playerId, action: Actions.Revive })).rejects.toThrow('You don\'t have enough coins')
       await actionHandler({ roomId, playerId: david.playerId, action: Actions.Income })


### PR DESCRIPTION
Flaky test setup caused by only choosing influence for 1 of 3 players. This caused collisions sometimes.