### PR TITLE
Submit confirmed actions only once

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,71 @@
+# AGENTS.md
+
+Guidance for AI coding agents working in this repo.
+
+## Never create a local `.pnpm-store`
+
+**Do not create, configure, or use a `.pnpm-store` (or any store path) inside this repository.** That is a recurring annoyance in this project.
+
+- Always use the default **user-level** pnpm store (outside the repo).
+- Never pass `--store-dir` / `store-dir` pointing into the workspace.
+- Never add a repo-local store via `.npmrc`, env vars, or install scripts.
+- If a repo-local `.pnpm-store` appears, **delete it immediately**.
+
+## Layout
+
+pnpm monorepo (Node `>=22`, packageManager `pnpm@11.1.3`):
+
+| Package | Role |
+| --- | --- |
+| `client/` | React 19 + Vite + MUI SPA |
+| `server/` | Express 5 + Socket.IO API |
+| `shared/` | Types, game rules helpers, i18n language list — used by client and server |
+
+Install and run from each package directory (`cd client` / `cd server` / `cd shared`). Prefer `pnpm` only (`only-allow pnpm` on preinstall).
+
+## Commands
+
+```sh
+# server
+cd server && pnpm i && pnpm dev
+cd server && pnpm test          # vitest; server must be up for integration tests
+cd server && pnpm lint && pnpm typecheck
+
+# client
+cd client && pnpm i && pnpm start
+cd client && pnpm test          # vitest unit tests
+cd client && pnpm lint && pnpm typecheck
+
+# Cypress (binary is NOT installed on pnpm install)
+cd client && pnpm cypress install
+cd client && pnpm cypress open  # or CI: pnpm cypress run
+```
+
+Build shared before client typecheck/start when needed: `pnpm build-shared` (via client scripts) or `pnpm --prefix shared build`.
+
+## Hard constraints
+
+- **Do not enable Cypress `allowBuilds` / postinstall.** Keep `cypress: false` in `client/pnpm-workspace.yaml`. Install the binary on demand with `pnpm cypress install` (CI already does this).
+- **Keep client/server on TypeScript 6.x** while they use `typescript-eslint`. TS 7 has no programmatic API yet; eslint support waits on TS 7.1+. `shared` may use TS 7 (CLI-only).
+- **Do not commit** unless the user asks. Do not force-push `main`/`master`.
+
+## Architecture notes
+
+- Real-time play is Socket.IO-first; HTTPS REST is the fallback for the same player actions.
+- Game mutations are **server-authoritative**. Shared helpers like `canPlayerChooseAction*` gate UI and AI; the server re-validates inside handlers and throws `GameMutationInputError` subclasses (e.g. `ActionNotCurrentlyAllowedError`).
+- Client mutations go through `useGameMutation` → `socket.emit` / HTTP. `PlayerActionConfirmation` auto-submits when confirm-actions is off — submit **once per mount** (avoid effect re-fires on unstable `variables`/`trigger` identities).
+- Put cross-cutting game rules in `shared/`; keep Express thin and logic in `server/src/game/`.
+
+## i18n
+
+New languages:
+
+1. `shared/i18n/availableLanguages.ts`
+2. `client/src/i18n/translations.ts`
+3. `server/src/i18n/translations.ts`
+
+## Style
+
+- Match existing patterns; small, focused diffs.
+- Do not add drive-by refactors, extra docs, or unsolicited dependency upgrades.
+- Prefer shared logic over duplicating client/server checks.

--- a/client/src/components/game/PlayerActionConfirmation.spec.tsx
+++ b/client/src/components/game/PlayerActionConfirmation.spec.tsx
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render as testingLibraryRender, act } from '@testing-library/react'
+import { PlayerActions } from '@shared'
+import { UserSettingsContext } from '../../contexts/UserSettingsContext'
+import { TranslationContext } from '../../contexts/TranslationsContext'
+import { GameStateContext } from '../../contexts/GameStateContext'
+import MaterialThemeContextProvider from '../../contexts/MaterialThemeContextProvider'
+import { getRandomGameState } from '../../../tests/utilities/render'
+import PlayerActionConfirmation from './PlayerActionConfirmation'
+
+const trigger = vi.fn()
+
+vi.mock('../../hooks/useGameMutation', () => ({
+  default: () => ({
+    trigger,
+    isMutating: false,
+  }),
+}))
+
+describe('PlayerActionConfirmation', () => {
+  beforeEach(() => {
+    trigger.mockClear()
+  })
+
+  it('auto-submits only once when confirmActions is off even if variables identity changes', () => {
+    const gameState = getRandomGameState()
+    const onCancel = vi.fn()
+
+    const { rerender } = testingLibraryRender(
+      <MaterialThemeContextProvider>
+        <GameStateContext.Provider value={{
+          gameState,
+          setDehydratedGameState: () => { },
+          hasInitialStateLoaded: true,
+          serverTimeOffset: 0,
+        }}>
+          <TranslationContext.Provider value={{
+            t: (key) => key,
+            language: 'en-US' as never,
+            setLanguage: () => { },
+          }}>
+            <UserSettingsContext.Provider value={{
+              showBackgroundImage: true,
+              confirmActions: false,
+              setShowBackgroundImage: () => { },
+              setConfirmActions: () => { },
+            }}>
+              <PlayerActionConfirmation
+                message="confirm"
+                action={PlayerActions.action}
+                variables={{ roomId: gameState.roomId, playerId: 'p1', action: 'Tax' }}
+                onCancel={onCancel}
+              />
+            </UserSettingsContext.Provider>
+          </TranslationContext.Provider>
+        </GameStateContext.Provider>
+      </MaterialThemeContextProvider>
+    )
+
+    expect(trigger).toHaveBeenCalledTimes(1)
+
+    act(() => {
+      rerender(
+        <MaterialThemeContextProvider>
+          <GameStateContext.Provider value={{
+            gameState,
+            setDehydratedGameState: () => { },
+            hasInitialStateLoaded: true,
+            serverTimeOffset: 0,
+          }}>
+            <TranslationContext.Provider value={{
+              t: (key) => key,
+              language: 'en-US' as never,
+              setLanguage: () => { },
+            }}>
+              <UserSettingsContext.Provider value={{
+                showBackgroundImage: true,
+                confirmActions: false,
+                setShowBackgroundImage: () => { },
+                setConfirmActions: () => { },
+              }}>
+                <PlayerActionConfirmation
+                  message="confirm"
+                  action={PlayerActions.action}
+                  variables={{ roomId: gameState.roomId, playerId: 'p1', action: 'Tax' }}
+                  onCancel={onCancel}
+                />
+              </UserSettingsContext.Provider>
+            </TranslationContext.Provider>
+          </GameStateContext.Provider>
+        </MaterialThemeContextProvider>
+      )
+    })
+
+    expect(trigger).toHaveBeenCalledTimes(1)
+  })
+})

--- a/client/src/components/game/PlayerActionConfirmation.tsx
+++ b/client/src/components/game/PlayerActionConfirmation.tsx
@@ -22,11 +22,23 @@ function PlayerActionConfirmation({
 }) {
   const [autoSubmitProgress, setAutoSubmitProgress] = useState(0)
   const autoSubmitInterval = useRef<ReturnType<typeof setInterval>>(undefined)
+  const hasSubmitted = useRef(false)
+  const variablesRef = useRef(variables)
+  const triggerRef = useRef<(params: object) => void>(() => { })
   const { gameState } = useGameStateContext()
   const { t } = useTranslationContext()
   const theme = useTheme()
   const { trigger, isMutating } = useGameMutation<object>({ action })
   const { confirmActions } = useUserSettingsContext()
+
+  variablesRef.current = variables
+  triggerRef.current = trigger
+
+  const submit = () => {
+    if (hasSubmitted.current) return
+    hasSubmitted.current = true
+    triggerRef.current(variablesRef.current)
+  }
 
   useEffect(() => {
     if (confirmActions) {
@@ -34,22 +46,22 @@ function PlayerActionConfirmation({
         setAutoSubmitProgress((prev) => Math.min(100, prev + 1))
       }, 50)
     } else {
-      trigger(variables)
+      submit()
     }
 
     return () => {
       clearInterval(autoSubmitInterval.current)
       autoSubmitInterval.current = undefined
     }
-  }, [confirmActions, trigger, variables])
+  }, [confirmActions])
 
   useEffect(() => {
     if (autoSubmitInterval.current && autoSubmitProgress === 100) {
       clearInterval(autoSubmitInterval.current)
       autoSubmitInterval.current = undefined
-      trigger(variables)
+      submit()
     }
-  }, [autoSubmitProgress, trigger, variables])
+  }, [autoSubmitProgress])
 
   if (!gameState || !confirmActions) {
     return null
@@ -97,7 +109,7 @@ function PlayerActionConfirmation({
               clearInterval(autoSubmitInterval.current)
               autoSubmitInterval.current = undefined
               setAutoSubmitProgress(100)
-              trigger(variables)
+              submit()
             }}
             loading={isMutating}
           >


### PR DESCRIPTION
## Summary
- Guard `PlayerActionConfirmation` so auto-submit (and confirm click) only emit once per mount
- Avoids duplicate socket actions when `variables`/`trigger` change identity with `confirmActions` disabled (Cypress / user setting)

## Test plan
- [ ] With confirm actions off: choose Tax once; server receives a single `action` event
- [ ] With confirm actions on: progress auto-submit and manual Confirm still work; Cancel still cancels
- [ ] Cypress `Games` e2e no longer floods server logs with `ActionNotCurrentlyAllowedError` for Tax/Pass/Steal


Made with [Cursor](https://cursor.com)